### PR TITLE
feat: optional order nodes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,13 +4,13 @@ import { Reporter } from "gatsby-cli/lib/reporter/reporter";
 function medusaRequest(
   storeURL: string,
   path = "",
-  payload = {}
+  headers = {}
 ): AxiosPromise {
   const options: AxiosRequestConfig = {
     method: "GET",
     withCredentials: true,
     url: path,
-    data: payload,
+    headers: headers,
   };
 
   const client = axios.create({ baseURL: storeURL });
@@ -22,7 +22,7 @@ export const createClient = (
   options: MedusaPluginOptions,
   reporter: Reporter
 ) => {
-  const { storeUrl } = options;
+  const { storeUrl, authToken } = options;
 
   /**
    *
@@ -93,8 +93,34 @@ export const createClient = (
     return regions;
   }
 
+  /**
+   *
+   * @param date used fetch regions updated since the specified date
+   * @returns
+   */
+  async function orders(date?: string) {
+    const orders = await medusaRequest(
+      storeUrl,
+      `/admin/orders${date ? `?updated_at[gte]=${date}&` : ""}`,
+      {
+        Authorization: `Bearer ${authToken}`,
+      }
+    )
+      .then(({ data }) => {
+        return data.orders;
+      })
+      .catch((error) => {
+        console.warn(`
+            "The following error status was produced while attempting to fetch regions: ${error}
+      `);
+        return [];
+      });
+    return orders;
+  }
+
   return {
     products,
     regions,
+    orders,
   };
 };

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -20,12 +20,17 @@ async function sourceAllNodes(
   gatsbyApi: SourceNodesArgs,
   pluginOptions: MedusaPluginOptions
 ): Promise<void> {
-  const { createProductsOperation, createRegionsOperation } = createOperations(
-    pluginOptions,
-    gatsbyApi
-  );
+  const {
+    createProductsOperation,
+    createRegionsOperation,
+    createOrdersOperation,
+  } = createOperations(pluginOptions, gatsbyApi);
 
   const operations = [createProductsOperation, createRegionsOperation];
+
+  if (pluginOptions.authToken) {
+    operations.push(createOrdersOperation);
+  }
 
   const sourceFromOperation = makeSourceFromOperation(gatsbyApi);
 
@@ -36,13 +41,15 @@ async function sourceAllNodes(
 
 const medusaNodeTypes = ["MedusaRegions", "MedusaProducts", "MedusaOrders"];
 
-// @TODO: Add once query by updated_since has been added
 async function sourceUpdatedNodes(
   gatsbyApi: SourceNodesArgs,
   pluginOptions: MedusaPluginOptions
 ): Promise<void> {
-  const { incrementalProductsOperation, incrementalRegionsOperation } =
-    createOperations(pluginOptions, gatsbyApi);
+  const {
+    incrementalProductsOperation,
+    incrementalRegionsOperation,
+    incrementalOrdersOperation,
+  } = createOperations(pluginOptions, gatsbyApi);
 
   const lastBuildTime = new Date(
     gatsbyApi.store.getState().status.plugins?.[`gatsby-source-medusa`]?.[
@@ -61,6 +68,10 @@ async function sourceUpdatedNodes(
     incrementalRegionsOperation(lastBuildTime),
   ];
 
+  if (pluginOptions.authToken) {
+    operations.push(incrementalOrdersOperation(lastBuildTime));
+  }
+
   const sourceFromOperation = makeSourceFromOperation(gatsbyApi);
 
   for (const op of operations) {
@@ -78,10 +89,6 @@ export async function sourceNodes(
   const lastBuildTime = pluginStatus?.[`lastBuildTime`];
 
   if (lastBuildTime !== undefined) {
-    /**
-     * We should add a way to retrieve products and regions that have
-     * been updated/created since last build time to support incremental builds.
-     */
     gatsbyApi.reporter.info(`Cache is warm, running an incremental build`);
     await sourceUpdatedNodes(gatsbyApi, pluginOptions);
   } else {

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -8,7 +8,7 @@ export function createOperations(
   const client = createClient(options, reporter);
 
   function createOperation(
-    name: "products" | "regions",
+    name: "products" | "regions" | "orders",
     queryString?: string
   ): IMedusaOperation {
     return {
@@ -20,9 +20,12 @@ export function createOperations(
   return {
     createProductsOperation: createOperation("products"),
     createRegionsOperation: createOperation("regions"),
+    createOrdersOperation: createOperation("orders"),
     incrementalProductsOperation: (date: Date) =>
       createOperation("products", date.toISOString()),
     incrementalRegionsOperation: (date: Date) =>
-      createOperation("products", date.toISOString()),
+      createOperation("regions", date.toISOString()),
+    incrementalOrdersOperation: (date: Date) =>
+      createOperation("orders", date.toISOString()),
   };
 }

--- a/types/interface.d.ts
+++ b/types/interface.d.ts
@@ -11,6 +11,8 @@ interface IMedusaOperation {
 interface IOperations {
   createProductsOperation: IMedusaOperation;
   createRegionsOperation: IMedusaOperation;
+  createOrdersOperation: IMedusaOperation;
   incrementalProductsOperation: (date: Date) => IMedusaOperation;
   incrementalRegionsOperation: (date: Date) => IMedusaOperation;
+  incrementalOrdersOperation: (date: Date) => IMedusaOperation;
 }


### PR DESCRIPTION
**What**
- Enables loading orders at build time using api key

**Why**
- Enables creating functionality such as toasters with "A customer from Copenhagen bought a Medusa Waterbottle, 2 min ago".

**How**

- Allows an optional plugin option `authToken` that can populated with an api key. This key is then used to retrieve all orders from the `admin/orders` endpoint.

**Note**

- This should be used with some caution as it is possible to expose private data when loading in orders. You must make sure not to expose any sensitive data to your sites visitors.